### PR TITLE
Correct blosc compression bytes

### DIFF
--- a/HCK02_2023_Allen_Institute_Hybrid/Tutorials/WorkingWithOMEZarrNGFF/OME-Zarr_Structure.ipynb
+++ b/HCK02_2023_Allen_Institute_Hybrid/Tutorials/WorkingWithOMEZarrNGFF/OME-Zarr_Structure.ipynb
@@ -1071,7 +1071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 22,
    "id": "0fcb2bab-5170-4a98-9149-4684ed88bbab",
    "metadata": {},
    "outputs": [],
@@ -1103,7 +1103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 23,
    "id": "40cc0d7a-5060-4aa7-b844-d1fbda934a7f",
    "metadata": {},
    "outputs": [
@@ -1120,7 +1120,7 @@
        " 'ContentType': 'binary/octet-stream'}"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1132,7 +1132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 24,
    "id": "1a9164e6-4f22-403d-95e6-cff883ddc943",
    "metadata": {},
    "outputs": [
@@ -1301,7 +1301,7 @@
        "dask.array<from-zarr, shape=(1, 1, 1050, 2560, 1850), dtype=uint16, chunksize=(1, 1, 1, 2560, 1850), chunktype=numpy.ndarray>"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1313,7 +1313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 25,
    "id": "3ac66ef6-e17a-4c85-85d9-55ccdbb87080",
    "metadata": {},
    "outputs": [],
@@ -1324,18 +1324,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 26,
    "id": "fd96174c-8c54-4bd4-852e-c0a1a298a5de",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Blosc compression: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.03335377956081081</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Blosc compression: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.18219647381756757</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "Blosc compression: \u001b[1;36m0.03335377956081081\u001b[0m\n"
+       "Blosc compression: \u001b[1;36m0.18219647381756757\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -1343,12 +1343,12 @@
     }
    ],
    "source": [
-    "print(f'Blosc compression: {315927 / chunk_data.nbytes}')"
+    "print(f'Blosc compression: {1725765 / chunk_data.nbytes}')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "83cc3e01-d5c5-41b6-a131-fdf73209288f",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
The bytes of the compressed data come from the stored zarr object -- the current value was derived from a different scale.

Bug caught by @danielsf 